### PR TITLE
Correctly Group Assign Blocks

### DIFF
--- a/include/include_HEADERS
+++ b/include/include_HEADERS
@@ -177,6 +177,7 @@ include_HEADERS =  \
         mesh/abaqus_io.h \
         mesh/boundary_info.h \
         mesh/boundary_mesh.h \
+        mesh/cdb_io.h \
         mesh/checkpoint_io.h \
         mesh/distributed_mesh.h \
         mesh/dyna_io.h \

--- a/include/libmesh/Makefile.am
+++ b/include/libmesh/Makefile.am
@@ -167,6 +167,7 @@ BUILT_SOURCES = \
         abaqus_io.h \
         boundary_info.h \
         boundary_mesh.h \
+        cdb_io.h \
         checkpoint_io.h \
         distributed_mesh.h \
         dyna_io.h \
@@ -1073,6 +1074,9 @@ boundary_info.h: $(top_srcdir)/include/mesh/boundary_info.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 boundary_mesh.h: $(top_srcdir)/include/mesh/boundary_mesh.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+cdb_io.h: $(top_srcdir)/include/mesh/cdb_io.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 checkpoint_io.h: $(top_srcdir)/include/mesh/checkpoint_io.h

--- a/include/libmesh/Makefile.in
+++ b/include/libmesh/Makefile.in
@@ -183,11 +183,11 @@ am__v_P_1 = :
 AM_V_GEN = $(am__v_GEN_@AM_V@)
 am__v_GEN_ = $(am__v_GEN_@AM_DEFAULT_V@)
 am__v_GEN_0 = @echo "  GEN     " $@;
-am__v_GEN_1 =
+am__v_GEN_1 = 
 AM_V_at = $(am__v_at_@AM_V@)
 am__v_at_ = $(am__v_at_@AM_DEFAULT_V@)
 am__v_at_0 = @
-am__v_at_1 =
+am__v_at_1 = 
 SOURCES =
 DIST_SOURCES =
 am__can_run_installinfo = \
@@ -565,21 +565,21 @@ BUILT_SOURCES = auto_ptr.h dirichlet_boundaries.h dof_map.h \
 	surface.h default_coupling.h ghost_point_neighbors.h \
 	ghosting_functor.h point_neighbor_coupling.h \
 	sibling_coupling.h abaqus_io.h boundary_info.h boundary_mesh.h \
-	checkpoint_io.h distributed_mesh.h dyna_io.h ensight_io.h \
-	exodusII_io.h exodusII_io_helper.h exodus_header_info.h \
-	fro_io.h gmsh_io.h gmv_io.h gnuplot_io.h inf_elem_builder.h \
-	matlab_io.h medit_io.h mesh.h mesh_base.h mesh_communication.h \
-	mesh_function.h mesh_generation.h mesh_input.h \
-	mesh_inserter_iterator.h mesh_modification.h mesh_output.h \
-	mesh_refinement.h mesh_serializer.h mesh_smoother.h \
-	mesh_smoother_laplace.h mesh_smoother_vsmoother.h \
-	mesh_subdivision_support.h mesh_tetgen_interface.h \
-	mesh_tetgen_wrapper.h mesh_tools.h mesh_triangle_holes.h \
-	mesh_triangle_interface.h mesh_triangle_wrapper.h \
-	namebased_io.h nemesis_io.h nemesis_io_helper.h off_io.h \
-	parallel_mesh.h patch.h poly2tri_triangulator.h \
-	postscript_io.h replicated_mesh.h serial_mesh.h \
-	sync_refinement_flags.h tecplot_io.h tetgen_io.h \
+	cdb_io.h checkpoint_io.h distributed_mesh.h dyna_io.h \
+	ensight_io.h exodusII_io.h exodusII_io_helper.h \
+	exodus_header_info.h fro_io.h gmsh_io.h gmv_io.h gnuplot_io.h \
+	inf_elem_builder.h matlab_io.h medit_io.h mesh.h mesh_base.h \
+	mesh_communication.h mesh_function.h mesh_generation.h \
+	mesh_input.h mesh_inserter_iterator.h mesh_modification.h \
+	mesh_output.h mesh_refinement.h mesh_serializer.h \
+	mesh_smoother.h mesh_smoother_laplace.h \
+	mesh_smoother_vsmoother.h mesh_subdivision_support.h \
+	mesh_tetgen_interface.h mesh_tetgen_wrapper.h mesh_tools.h \
+	mesh_triangle_holes.h mesh_triangle_interface.h \
+	mesh_triangle_wrapper.h namebased_io.h nemesis_io.h \
+	nemesis_io_helper.h off_io.h parallel_mesh.h patch.h \
+	poly2tri_triangulator.h postscript_io.h replicated_mesh.h \
+	serial_mesh.h sync_refinement_flags.h tecplot_io.h tetgen_io.h \
 	triangulator_interface.h ucd_io.h unstructured_mesh.h unv_io.h \
 	vtk_io.h xdr_io.h analytic_function.h composite_fem_function.h \
 	composite_function.h const_fem_function.h const_function.h \
@@ -604,16 +604,17 @@ BUILT_SOURCES = auto_ptr.h dirichlet_boundaries.h dof_map.h \
 	wrapped_functor.h wrapped_petsc.h zero_function.h \
 	libmesh_call_mpi.h parallel.h parallel_algebra.h \
 	parallel_bin_sorter.h parallel_conversion_utils.h \
-	parallel_eigen.h parallel_elem.h parallel_fe_type.h parallel_ghost_sync.h \
-	parallel_hilbert.h parallel_histogram.h parallel_node.h \
-	parallel_object.h parallel_only.h parallel_sort.h threads.h \
-	threads_allocators.h threads_none.h threads_pthread.h \
-	threads_tbb.h centroid_partitioner.h hilbert_sfc_partitioner.h \
-	linear_partitioner.h mapped_subdomain_partitioner.h \
-	metis_csr_graph.h metis_partitioner.h morton_sfc_partitioner.h \
-	parmetis_helper.h parmetis_partitioner.h partitioner.h \
-	sfc_partitioner.h subdomain_partitioner.h diff_physics.h \
-	diff_qoi.h fem_physics.h quadrature.h quadrature_clough.h \
+	parallel_eigen.h parallel_elem.h parallel_fe_type.h \
+	parallel_ghost_sync.h parallel_hilbert.h parallel_histogram.h \
+	parallel_node.h parallel_object.h parallel_only.h \
+	parallel_sort.h threads.h threads_allocators.h threads_none.h \
+	threads_pthread.h threads_tbb.h centroid_partitioner.h \
+	hilbert_sfc_partitioner.h linear_partitioner.h \
+	mapped_subdomain_partitioner.h metis_csr_graph.h \
+	metis_partitioner.h morton_sfc_partitioner.h parmetis_helper.h \
+	parmetis_partitioner.h partitioner.h sfc_partitioner.h \
+	subdomain_partitioner.h diff_physics.h diff_qoi.h \
+	fem_physics.h quadrature.h quadrature_clough.h \
 	quadrature_composite.h quadrature_conical.h quadrature_gauss.h \
 	quadrature_gauss_lobatto.h quadrature_gm.h quadrature_grid.h \
 	quadrature_jacobi.h quadrature_monomial.h quadrature_nodal.h \
@@ -1407,6 +1408,9 @@ boundary_info.h: $(top_srcdir)/include/mesh/boundary_info.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 boundary_mesh.h: $(top_srcdir)/include/mesh/boundary_mesh.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
+
+cdb_io.h: $(top_srcdir)/include/mesh/cdb_io.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) -f $< $@
 
 checkpoint_io.h: $(top_srcdir)/include/mesh/checkpoint_io.h

--- a/include/libmesh/fparser_ad.hh
+++ b/include/libmesh/fparser_ad.hh
@@ -1,0 +1,1 @@
+../../contrib/fparser/fparser_ad.hh

--- a/src/libmesh_SOURCES
+++ b/src/libmesh_SOURCES
@@ -189,6 +189,7 @@ libmesh_SOURCES =  \
         src/mesh/abaqus_io.C \
         src/mesh/boundary_info.C \
         src/mesh/boundary_mesh.C \
+        src/mesh/cdb_io.C \
         src/mesh/checkpoint_io.C \
         src/mesh/distributed_mesh.C \
         src/mesh/dyna_io.C \


### PR DESCRIPTION
ANSYS Element blocks allow for multiple different element types in the same block. This behaviour is not compatible with Exodus files. Now element blocks are correctly assigned, and the block names have their corresponding libmesh element type appended.